### PR TITLE
feat(monitoring): upgrade Alloy and migrate telemetry to k8s tailnet endpoints

### DIFF
--- a/docs/superpowers/plans/2026-06-18-alloy-upgrade-endpoint-migration.md
+++ b/docs/superpowers/plans/2026-06-18-alloy-upgrade-endpoint-migration.md
@@ -1,0 +1,488 @@
+# Alloy Upgrade + Endpoint Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade the `grafana.grafana.alloy` deployment to collection 6.1.0 and migrate logs/metrics/traces to the new Tailscale-network k8s endpoints, fixing the OTLP receiver routing that currently drops all OTLP metrics and logs.
+
+**Architecture:** Three Ansible playbooks (`monitoring.yml`, `monitoring-hole.yml`, `monitoring-jitsi.yml`) configure the `grafana.grafana.alloy` role with an inline Alloy river config. Each playbook's embedded config is edited to point at the new endpoints, drop all client-side tenant config (endpoints auto-inject `X-Scope-Org-ID`), and switch Tempo to OTLP/HTTP. The `nuc` config additionally gains bridge exporters so OTLP-ingested metrics→Mimir and logs→Loki instead of all signals into Tempo.
+
+**Tech Stack:** Ansible (ansible-core 2.20.6 via mise), `grafana.grafana` collection 6.1.0, Grafana Alloy (river config), ansible-galaxy.
+
+## Global Constraints
+
+- Collection: `grafana.grafana` pinned to `6.1.0` (inline play pin AND `requirements.yml`).
+- Drop ALL client-side tenant config: no `tenant_id` (loki.write), no `X-Scope-OrgID` headers (mimir). Endpoints auto-inject the tenant header.
+- All new endpoints are HTTPS.
+- Endpoint mapping:
+  - `nuc` → `homelab-{mimir,loki,tempo}.k8s.specht-labs.de`
+  - `hole` → `spechtlabs-{mimir,loki,tempo}.k8s.specht-labs.de`
+  - `jitsi` → `spechtlabs-{mimir,loki,tempo}.k8s.specht-labs.de`
+- URL forms: Loki `https://<host>/loki/api/v1/push`; Mimir `https://<host>/api/v1/push`; Tempo `https://<host>/otlp` via `otelcol.exporter.otlphttp`.
+- Tooling: invoke ansible via `mise exec --` per the repo's tool-installation directive.
+- Preserve `jitsi`'s `external_labels { hostname }`, all scrape jobs, log sources, relabel rules, `alloy_user_groups`, `alloy_env_file_vars`.
+- No unit-test framework exists; verification = `ansible-playbook --syntax-check`, galaxy resolution, and live journal inspection on `nuc` (`ssh root@nuc`).
+
+---
+
+### Task 1: Pin collection 6.1.0 in requirements.yml
+
+**Files:**
+- Modify: `requirements.yml`
+
+**Interfaces:**
+- Produces: collection `grafana.grafana==6.1.0` resolvable by ansible-galaxy and by the inline play pins in Tasks 2–4.
+
+- [ ] **Step 1: Edit requirements.yml**
+
+Change the `grafana.grafana` entry from the bare name to a pinned version. Final file:
+
+```yaml
+---
+collections:
+  - name: community.general
+  - name: ansible.posix
+  - name: grafana.grafana
+    version: "6.1.0"
+
+roles:
+  - name: geerlingguy.node_exporter
+  - name: artis3n.tailscale
+  - name: geerlingguy.nut_client
+```
+
+- [ ] **Step 2: Install/resolve the collection**
+
+Run: `cd /Users/cedi/src/gh/cedi/homelab-ansible && mise exec -- ansible-galaxy collection install -r requirements.yml -p .ansible/collections --force`
+Expected: output includes `grafana.grafana:6.1.0 was installed successfully`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add requirements.yml
+git commit -m "build: pin grafana.grafana collection to 6.1.0"
+```
+
+---
+
+### Task 2: Migrate nuc (monitoring.yml) — endpoints, tenancy, Tempo, OTLP routing fix
+
+**Files:**
+- Modify: `playbooks/monitoring.yml`
+
+**Interfaces:**
+- Consumes: `grafana.grafana` 6.1.0 (Task 1).
+- Produces: working `nuc` Alloy config where OTLP metrics→Mimir, logs→Loki, traces→Tempo.
+
+- [ ] **Step 1: Bump the inline collection pin**
+
+In `playbooks/monitoring.yml`, change:
+
+```yaml
+  collections:
+    - grafana.grafana:5.7.0
+```
+
+to:
+
+```yaml
+  collections:
+    - grafana.grafana:6.1.0
+```
+
+- [ ] **Step 2: Migrate the Loki endpoint and drop tenant_id**
+
+Replace the `loki.write "grafana_loki"` block:
+
+```alloy
+          loki.write "grafana_loki" {
+            endpoint {
+              url       = "https://loki-gateway.sphinx-map.ts.net/loki/api/v1/push"
+              tenant_id = "homelab"
+            }
+          }
+```
+
+with:
+
+```alloy
+          loki.write "grafana_loki" {
+            endpoint {
+              url = "https://homelab-loki.k8s.specht-labs.de/loki/api/v1/push"
+            }
+          }
+```
+
+- [ ] **Step 3: Migrate the Mimir endpoint and drop the X-Scope-OrgID header**
+
+Replace the `prometheus.remote_write "mimir"` block:
+
+```alloy
+          prometheus.remote_write "mimir" {
+            endpoint {
+              url = "https://mimir-nginx.sphinx-map.ts.net/api/v1/push"
+              headers = {
+                "X-Scope-OrgID" = "homelab",
+              }
+            }
+          }
+```
+
+with:
+
+```alloy
+          prometheus.remote_write "mimir" {
+            endpoint {
+              url = "https://homelab-mimir.k8s.specht-labs.de/api/v1/push"
+            }
+          }
+```
+
+- [ ] **Step 4: Replace the Tempo exporter and fix OTLP receiver routing**
+
+Replace the entire trailing block (the `otelcol.exporter.otlp "tempo"` and `otelcol.receiver.otlp "default"` definitions):
+
+```alloy
+          otelcol.exporter.otlp "tempo" {
+            client {
+              endpoint = "tempo-distributor.sphinx-map.ts.net/otlp-http"
+            }
+          }
+
+          otelcol.receiver.otlp "default" {
+            grpc {
+              endpoint = "0.0.0.0:4317"
+            }
+            http {
+              endpoint = "0.0.0.0:4318"
+            }
+            output {
+              metrics = [otelcol.exporter.otlp.tempo.input]
+              logs    = [otelcol.exporter.otlp.tempo.input]
+              traces  = [otelcol.exporter.otlp.tempo.input]
+            }
+          }
+```
+
+with:
+
+```alloy
+          otelcol.exporter.otlphttp "tempo" {
+            client {
+              endpoint = "https://homelab-tempo.k8s.specht-labs.de/otlp"
+            }
+          }
+
+          otelcol.exporter.prometheus "to_mimir" {
+            forward_to = [prometheus.remote_write.mimir.receiver]
+          }
+
+          otelcol.exporter.loki "to_loki" {
+            forward_to = [loki.write.grafana_loki.receiver]
+          }
+
+          otelcol.receiver.otlp "default" {
+            grpc {
+              endpoint = "0.0.0.0:4317"
+            }
+            http {
+              endpoint = "0.0.0.0:4318"
+            }
+            output {
+              metrics = [otelcol.exporter.prometheus.to_mimir.input]
+              logs    = [otelcol.exporter.loki.to_loki.input]
+              traces  = [otelcol.exporter.otlphttp.tempo.input]
+            }
+          }
+```
+
+- [ ] **Step 5: Syntax-check**
+
+Run: `cd /Users/cedi/src/gh/cedi/homelab-ansible && mise exec -- ansible-playbook -i inventory/homelab.yaml playbooks/monitoring.yml --syntax-check`
+Expected: exit 0, no errors (prints the playbook name).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add playbooks/monitoring.yml
+git commit -m "feat: migrate nuc alloy to homelab k8s endpoints and fix OTLP routing"
+```
+
+---
+
+### Task 3: Migrate hole (monitoring-hole.yml) — endpoints, tenancy, Tempo, systemd fix
+
+**Files:**
+- Modify: `playbooks/monitoring-hole.yml`
+
+**Interfaces:**
+- Consumes: `grafana.grafana` 6.1.0 (Task 1).
+- Produces: working `hole` Alloy config on `spechtlabs-*` endpoints with a correctly-applied `User=root` override.
+
+- [ ] **Step 1: Bump the inline collection pin**
+
+Change `- grafana.grafana:5.7.0` to `- grafana.grafana:6.1.0`.
+
+- [ ] **Step 2: Fix the malformed alloy_systemd_override nesting**
+
+Replace:
+
+```yaml
+        alloy_systemd_override:
+          alloy_systemd_override: |
+            [Service]
+            User=root
+```
+
+with:
+
+```yaml
+        alloy_systemd_override: |
+          [Service]
+          User=root
+```
+
+- [ ] **Step 3: Migrate the Loki endpoint and drop tenant_id**
+
+Replace:
+
+```alloy
+          loki.write "grafana_loki" {
+            endpoint {
+              url       = "https://loki-gateway.sphinx-map.ts.net/loki/api/v1/push"
+              tenant_id = "cedi-dev"
+            }
+          }
+```
+
+with:
+
+```alloy
+          loki.write "grafana_loki" {
+            endpoint {
+              url = "https://spechtlabs-loki.k8s.specht-labs.de/loki/api/v1/push"
+            }
+          }
+```
+
+- [ ] **Step 4: Migrate the Mimir endpoint and drop the X-Scope-OrgID header**
+
+Replace:
+
+```alloy
+          prometheus.remote_write "mimir" {
+            endpoint {
+              url = "https://mimir-nginx.sphinx-map.ts.net/api/v1/push"
+              headers = {
+                "X-Scope-OrgID" = "cedi-dev",
+              }
+            }
+          }
+```
+
+with:
+
+```alloy
+          prometheus.remote_write "mimir" {
+            endpoint {
+              url = "https://spechtlabs-mimir.k8s.specht-labs.de/api/v1/push"
+            }
+          }
+```
+
+- [ ] **Step 5: Migrate the Tempo exporter to OTLP/HTTP**
+
+Replace:
+
+```alloy
+          otelcol.exporter.otlp "tempo" {
+            client {
+              endpoint = "tempo-distributor.sphinx-map.ts.net/otlp-http"
+            }
+          }
+```
+
+with:
+
+```alloy
+          otelcol.exporter.otlphttp "tempo" {
+            client {
+              endpoint = "https://spechtlabs-tempo.k8s.specht-labs.de/otlp"
+            }
+          }
+```
+
+- [ ] **Step 6: Syntax-check**
+
+Run: `cd /Users/cedi/src/gh/cedi/homelab-ansible && mise exec -- ansible-playbook -i inventory/homelab.yaml playbooks/monitoring-hole.yml --syntax-check`
+Expected: exit 0, no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add playbooks/monitoring-hole.yml
+git commit -m "feat: migrate hole alloy to spechtlabs k8s endpoints and fix systemd override"
+```
+
+---
+
+### Task 4: Migrate jitsi (monitoring-jitsi.yml) — endpoints, tenancy, Tempo, systemd fix
+
+**Files:**
+- Modify: `playbooks/monitoring-jitsi.yml`
+
+**Interfaces:**
+- Consumes: `grafana.grafana` 6.1.0 (Task 1).
+- Produces: working `jitsi` Alloy config on `spechtlabs-*` endpoints, `external_labels` preserved.
+
+- [ ] **Step 1: Bump the inline collection pin**
+
+Change `- grafana.grafana:5.7.0` to `- grafana.grafana:6.1.0`.
+
+- [ ] **Step 2: Fix the malformed alloy_systemd_override nesting**
+
+Replace:
+
+```yaml
+        alloy_systemd_override:
+          alloy_systemd_override: |
+            [Service]
+            User=root
+```
+
+with:
+
+```yaml
+        alloy_systemd_override: |
+          [Service]
+          User=root
+```
+
+- [ ] **Step 3: Migrate the Loki endpoint and drop tenant_id (preserve external_labels)**
+
+Replace:
+
+```alloy
+          loki.write "grafana_loki" {
+            endpoint {
+              url       = "https://loki-gateway.sphinx-map.ts.net/loki/api/v1/push"
+              tenant_id = "cedi-dev"
+            }
+
+            external_labels = {
+              hostname = "meet.realschule-rottweil.de",
+            }
+          }
+```
+
+with:
+
+```alloy
+          loki.write "grafana_loki" {
+            endpoint {
+              url = "https://spechtlabs-loki.k8s.specht-labs.de/loki/api/v1/push"
+            }
+
+            external_labels = {
+              hostname = "meet.realschule-rottweil.de",
+            }
+          }
+```
+
+- [ ] **Step 4: Migrate the Mimir endpoint and drop the X-Scope-OrgID header**
+
+Replace:
+
+```alloy
+          prometheus.remote_write "mimir" {
+            endpoint {
+              url = "https://mimir-nginx.sphinx-map.ts.net/api/v1/push"
+              headers = {
+                "X-Scope-OrgID" = "cedi-dev",
+              }
+            }
+          }
+```
+
+with:
+
+```alloy
+          prometheus.remote_write "mimir" {
+            endpoint {
+              url = "https://spechtlabs-mimir.k8s.specht-labs.de/api/v1/push"
+            }
+          }
+```
+
+- [ ] **Step 5: Migrate the Tempo exporter to OTLP/HTTP**
+
+Replace:
+
+```alloy
+          otelcol.exporter.otlp "tempo" {
+            client {
+              endpoint = "tempo-distributor.sphinx-map.ts.net/otlp-http"
+            }
+          }
+```
+
+with:
+
+```alloy
+          otelcol.exporter.otlphttp "tempo" {
+            client {
+              endpoint = "https://spechtlabs-tempo.k8s.specht-labs.de/otlp"
+            }
+          }
+```
+
+- [ ] **Step 6: Syntax-check**
+
+Run: `cd /Users/cedi/src/gh/cedi/homelab-ansible && mise exec -- ansible-playbook -i inventory/homelab.yaml playbooks/monitoring-jitsi.yml --syntax-check`
+Expected: exit 0, no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add playbooks/monitoring-jitsi.yml
+git commit -m "feat: migrate jitsi alloy to spechtlabs k8s endpoints and fix systemd override"
+```
+
+---
+
+### Task 5: Deploy to nuc and verify the OTLP/endpoint fix live
+
+This is the real acceptance test: `nuc` is the only host with an OTLP receiver and was actively dropping data. Apply and confirm the error stream stops.
+
+**Files:** none (deploy + verify only)
+
+- [ ] **Step 1: Capture a baseline error count (pre-deploy)**
+
+Run: `ssh root@nuc 'journalctl -u alloy --since "-5min" --no-pager | grep -c "exporter.otlp.tempo"'`
+Expected: a non-zero count (the current failing stream).
+
+- [ ] **Step 2: Apply the nuc playbook**
+
+Run: `cd /Users/cedi/src/gh/cedi/homelab-ansible && mise exec -- ansible-playbook -i inventory/homelab.yaml playbooks/monitoring.yml`
+Expected: play recap shows `failed=0`; the alloy config/service tasks report `changed`.
+
+- [ ] **Step 3: Confirm the new config is deployed**
+
+Run: `ssh root@nuc 'grep -E "otelcol.exporter|specht-labs" /etc/alloy/config.alloy'`
+Expected: shows `otelcol.exporter.otlphttp "tempo"`, `otelcol.exporter.prometheus "to_mimir"`, `otelcol.exporter.loki "to_loki"`, and the `homelab-*.k8s.specht-labs.de` endpoints. No `sphinx-map.ts.net` remains.
+
+- [ ] **Step 4: Confirm Alloy is healthy and errors stopped**
+
+Run: `ssh root@nuc 'systemctl is-active alloy; sleep 30; journalctl -u alloy --since "-1min" --no-pager | grep -iE "error|Dropping data|queue is full" | tail -20'`
+Expected: `active`; no `otelcol.exporter.otlp.tempo` connection-refused / queue-full / dropping-data errors. (Brief startup warnings are acceptable; a continuing error stream is not.)
+
+- [ ] **Step 5: Confirm no component-evaluation errors**
+
+Run: `ssh root@nuc 'journalctl -u alloy --since "-1min" --no-pager | grep -iE "level=error|failed to (build|evaluate)" | tail -20'`
+Expected: empty (no config-build/evaluation errors — confirms `otelcol.exporter.prometheus`/`otelcol.exporter.loki` resolve correctly on the deployed Alloy build).
+
+---
+
+## Notes on hole / jitsi deployment
+
+`hole` and `jitsi` are not in the default `mise` apply flow and `hole` is on a remote network. Deploy them when reachable with:
+`mise exec -- ansible-playbook -i inventory/homelab.yaml playbooks/monitoring-hole.yml` (and the jitsi equivalent). Their Alloy has no OTLP receiver, so the key checks are: service `active`, config shows `spechtlabs-*` endpoints, and `prometheus.remote_write`/`loki.write` show no push errors in the journal.

--- a/docs/superpowers/plans/2026-06-18-alloy-upgrade-endpoint-migration.md
+++ b/docs/superpowers/plans/2026-06-18-alloy-upgrade-endpoint-migration.md
@@ -8,6 +8,15 @@
 
 **Tech Stack:** Ansible (ansible-core 2.20.6 via mise), `grafana.grafana` collection 6.1.0, Grafana Alloy (river config), ansible-galaxy.
 
+> **Implementation corrections (discovered during deploy):**
+> 1. The new endpoints are HTTP on the envoy `tailnet` Gateway `:80` listener
+>    (tailnet-encrypted); `:443` is TLS-passthrough/TLSRoute-only. Use `http://`,
+>    not `https://`, for all Loki/Mimir/Tempo URLs.
+> 2. Tempo endpoint is the bare host `http://<host>` (otlphttp appends
+>    `/v1/traces`); the `/otlp` suffix returns 404.
+> 3. The 6.1.0 alloy role preflight needs the `ansible.utils` collection +
+>    `netaddr` Python lib — added an extra task (Task 0) for this.
+
 ## Global Constraints
 
 - Collection: `grafana.grafana` pinned to `6.1.0` (inline play pin AND `requirements.yml`).

--- a/docs/superpowers/specs/2026-06-18-alloy-upgrade-endpoint-migration-design.md
+++ b/docs/superpowers/specs/2026-06-18-alloy-upgrade-endpoint-migration-design.md
@@ -1,7 +1,7 @@
 # Alloy Upgrade + Endpoint Migration — Design
 
 **Date:** 2026-06-18
-**Status:** Approved
+**Status:** Pending re-approval (scope expanded to fix OTLP metrics/logs routing)
 
 ## Goal
 
@@ -60,13 +60,58 @@ Full URLs/paths (all HTTPS):
    }
    ```
 
-### monitoring.yml (nuc) — receiver reference only
+### monitoring.yml (nuc) — fix OTLP receiver routing (metrics/logs failure)
 
-The `otelcol.receiver.otlp "default"` output block keeps forwarding
-`metrics`, `logs`, and `traces` (left as-is per decision), but the exporter
-component name changes, so the three references update from
-`otelcol.exporter.otlp.tempo.input` →
-`otelcol.exporter.otlphttp.tempo.input`.
+**Root cause (confirmed on the live host, alloy v1.8.1):** the
+`otelcol.receiver.otlp "default"` output block forwards `metrics`, `logs`, AND
+`traces` all into the single Tempo exporter. Tempo only ingests traces, and the
+old Tempo endpoint is now down — the journal shows a continuous stream of
+`otelcol.exporter.otlp.tempo` errors (`connection refused`, `sending queue is
+full`, `Dropping data`). Every OTLP-ingested metric and log is dropped along
+with the traces. The direct paths (`prometheus.scrape`→Mimir, file/journal→Loki)
+are healthy.
+
+Fix: add bridge exporters so each signal goes to its correct backend.
+
+```alloy
+otelcol.exporter.otlphttp "tempo" {
+  client {
+    endpoint = "https://homelab-tempo.k8s.specht-labs.de/otlp"
+  }
+}
+
+otelcol.exporter.prometheus "to_mimir" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+}
+
+otelcol.exporter.loki "to_loki" {
+  forward_to = [loki.write.grafana_loki.receiver]
+}
+
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+  output {
+    metrics = [otelcol.exporter.prometheus.to_mimir.input]
+    logs    = [otelcol.exporter.loki.to_loki.input]
+    traces  = [otelcol.exporter.otlphttp.tempo.input]
+  }
+}
+```
+
+This supersedes step 4's Tempo change for `monitoring.yml` (the `otelcol.exporter.otlphttp "tempo"` block above is the nuc form).
+
+### hole / jitsi — Tempo exporter
+
+`hole` and `jitsi` define an `otelcol.exporter.*` "tempo" but have **no**
+`otelcol.receiver.otlp`, so nothing feeds it (no OTLP ingestion on those hosts).
+Step 4 still applies: convert it to `otelcol.exporter.otlphttp "tempo"` pointed
+at `https://spechtlabs-tempo.k8s.specht-labs.de/otlp`. It remains an inert
+(unreferenced) component, matching the pre-existing structure.
 
 ### monitoring-hole.yml & monitoring-jitsi.yml — systemd override fix
 

--- a/docs/superpowers/specs/2026-06-18-alloy-upgrade-endpoint-migration-design.md
+++ b/docs/superpowers/specs/2026-06-18-alloy-upgrade-endpoint-migration-design.md
@@ -1,0 +1,120 @@
+# Alloy Upgrade + Endpoint Migration — Design
+
+**Date:** 2026-06-18
+**Status:** Approved
+
+## Goal
+
+Upgrade the `grafana.grafana.alloy` deployment to the latest collection and
+migrate the logs/metrics/traces ingestion endpoints to the new Tailscale-network
+k8s endpoints. The new endpoints auto-inject the multi-tenant `X-Scope-Org-ID`
+header, so all client-side tenant configuration is removed.
+
+## Affected files
+
+- `playbooks/monitoring.yml` — host group `nuc`
+- `playbooks/monitoring-hole.yml` — host `hole`
+- `playbooks/monitoring-jitsi.yml` — host `meet` (jitsi)
+- `requirements.yml`
+
+## Endpoint mapping
+
+`nuc` keeps the `homelab` tenant lineage; `hole` and `jitsi` (formerly the
+`cedi-dev` tenant) move to the `spechtlabs` endpoints.
+
+| Host  | Metrics (Mimir)                          | Logs (Loki)                              | Traces (Tempo)                            |
+|-------|------------------------------------------|------------------------------------------|-------------------------------------------|
+| nuc   | `homelab-mimir.k8s.specht-labs.de`       | `homelab-loki.k8s.specht-labs.de`        | `homelab-tempo.k8s.specht-labs.de`        |
+| hole  | `spechtlabs-mimir.k8s.specht-labs.de`    | `spechtlabs-loki.k8s.specht-labs.de`     | `spechtlabs-tempo.k8s.specht-labs.de`     |
+| jitsi | `spechtlabs-mimir.k8s.specht-labs.de`    | `spechtlabs-loki.k8s.specht-labs.de`     | `spechtlabs-tempo.k8s.specht-labs.de`     |
+
+Full URLs/paths (all HTTPS):
+
+- **Loki**: `https://<host>/loki/api/v1/push`
+- **Mimir**: `https://<host>/api/v1/push`
+- **Tempo**: `https://<host>/otlp` (Alloy's `otelcol.exporter.otlphttp` appends `/v1/traces`)
+
+## Changes
+
+### All three playbooks
+
+1. **Collection version**: bump the inline play-level pin
+   `grafana.grafana:5.7.0` → `grafana.grafana:6.1.0`.
+
+2. **Loki (`loki.write "grafana_loki"`)**:
+   - Set `url` to the host's Loki push URL.
+   - **Remove** the `tenant_id` argument (server auto-injects the tenant header).
+
+3. **Mimir (`prometheus.remote_write "mimir"`)**:
+   - Set `url` to the host's Mimir push URL.
+   - **Remove** the `headers = { "X-Scope-OrgID" = ... }` block.
+
+4. **Tempo**: replace `otelcol.exporter.otlp "tempo"` (gRPC) with
+   `otelcol.exporter.otlphttp "tempo"`:
+
+   ```alloy
+   otelcol.exporter.otlphttp "tempo" {
+     client {
+       endpoint = "https://<host>/otlp"
+     }
+   }
+   ```
+
+### monitoring.yml (nuc) — receiver reference only
+
+The `otelcol.receiver.otlp "default"` output block keeps forwarding
+`metrics`, `logs`, and `traces` (left as-is per decision), but the exporter
+component name changes, so the three references update from
+`otelcol.exporter.otlp.tempo.input` →
+`otelcol.exporter.otlphttp.tempo.input`.
+
+### monitoring-hole.yml & monitoring-jitsi.yml — systemd override fix
+
+Both files currently have a malformed, double-nested `alloy_systemd_override`:
+
+```yaml
+alloy_systemd_override:
+  alloy_systemd_override: |
+    [Service]
+    User=root
+```
+
+Flatten to the correct string form (matching `monitoring.yml`) so the
+`User=root` override actually applies:
+
+```yaml
+alloy_systemd_override: |
+  [Service]
+  User=root
+```
+
+### requirements.yml
+
+Pin the collection so renovate can track and bump it:
+
+```yaml
+collections:
+  - name: community.general
+  - name: ansible.posix
+  - name: grafana.grafana
+    version: "6.1.0"
+```
+
+## Preserved as-is
+
+- `jitsi`'s `loki.write` `external_labels { hostname = "meet...." }` (not tenancy).
+- All `prometheus.scrape` jobs, log file/journal sources, relabel rules,
+  `alloy_user_groups`, and `alloy_env_file_vars`.
+
+## Out of scope (noted, not changed)
+
+- `site.yml` references a non-existent `metrics-collector.yml` and does not
+  import `monitoring-hole.yml` — pre-existing, untouched.
+- Alloy binary version stays at the role default (`latest`).
+
+## Verification
+
+- `mise exec -- ansible-playbook -i inventory/homelab.yaml playbooks/monitoring.yml --syntax-check`
+  (and the same for `monitoring-hole.yml`, `monitoring-jitsi.yml`).
+- Re-pull collections: `ansible-galaxy collection install -r requirements.yml`
+  resolves `grafana.grafana==6.1.0`.

--- a/docs/superpowers/specs/2026-06-18-alloy-upgrade-endpoint-migration-design.md
+++ b/docs/superpowers/specs/2026-06-18-alloy-upgrade-endpoint-migration-design.md
@@ -1,7 +1,17 @@
 # Alloy Upgrade + Endpoint Migration — Design
 
 **Date:** 2026-06-18
-**Status:** Pending re-approval (scope expanded to fix OTLP metrics/logs routing)
+**Status:** Implemented
+
+> **Correction discovered during deployment:** the new endpoints are served over
+> plain **HTTP on port 80** by the envoy `tailnet` Gateway (Tailscale/WireGuard
+> provides transport encryption). Its `:443` listener is TLS **Passthrough**
+> (TLSRoute-only), so `https://` reset at the TLS handshake. All endpoint URLs
+> below therefore use `http://`, not `https://`. Additionally, Tempo's OTLP/HTTP
+> receiver (the `tempo-distributor:4318` backend) serves `/v1/traces`, so the
+> `otelcol.exporter.otlphttp` endpoint is the bare host `http://<host>` (the
+> exporter appends `/v1/traces`) — no `/otlp` suffix. The implemented playbooks
+> reflect these corrections.
 
 ## Goal
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,13 @@
 ansible-core = "2.20.6"
 uv = "0.11.19"
 
+[tasks."deps"]
+description = "Install Ansible galaxy roles/collections and controller Python deps"
+run = """
+ansible-galaxy install -r requirements.yml
+uv pip install --python "$(mise where ansible-core)/ansible-core/bin/python" -r requirements.txt
+"""
+
 [tasks."ansible:syntax"]
 description = "Syntax-check the full site playbook"
 run = "ansible-playbook -i inventory/homelab.yaml playbooks/site.yml --syntax-check"

--- a/playbooks/monitoring-hole.yml
+++ b/playbooks/monitoring-hole.yml
@@ -3,7 +3,7 @@
   gather_facts: true
   become: true
   collections:
-    - grafana.grafana:5.7.0
+    - grafana.grafana:6.1.0
   roles:
     - role: geerlingguy.node_exporter
     - role: grafana.grafana.alloy
@@ -12,15 +12,13 @@
           - "systemd-journal"
           - "adm"
           - "sudo"
-        alloy_systemd_override:
-          alloy_systemd_override: |
-            [Service]
-            User=root
+        alloy_systemd_override: |
+          [Service]
+          User=root
         alloy_config: |
           loki.write "grafana_loki" {
             endpoint {
-              url       = "https://loki-gateway.sphinx-map.ts.net/loki/api/v1/push"
-              tenant_id = "cedi-dev"
+              url = "https://spechtlabs-loki.k8s.specht-labs.de/loki/api/v1/push"
             }
           }
 
@@ -72,10 +70,7 @@
 
           prometheus.remote_write "mimir" {
             endpoint {
-              url = "https://mimir-nginx.sphinx-map.ts.net/api/v1/push"
-              headers = {
-                "X-Scope-OrgID" = "cedi-dev",
-              }
+              url = "https://spechtlabs-mimir.k8s.specht-labs.de/api/v1/push"
             }
           }
 
@@ -103,8 +98,8 @@
             forward_to = [prometheus.remote_write.mimir.receiver]
           }
 
-          otelcol.exporter.otlp "tempo" {
+          otelcol.exporter.otlphttp "tempo" {
             client {
-              endpoint = "tempo-distributor.sphinx-map.ts.net/otlp-http"
+              endpoint = "https://spechtlabs-tempo.k8s.specht-labs.de/otlp"
             }
           }

--- a/playbooks/monitoring-hole.yml
+++ b/playbooks/monitoring-hole.yml
@@ -18,7 +18,7 @@
         alloy_config: |
           loki.write "grafana_loki" {
             endpoint {
-              url = "https://spechtlabs-loki.k8s.specht-labs.de/loki/api/v1/push"
+              url = "http://spechtlabs-loki.k8s.specht-labs.de/loki/api/v1/push"
             }
           }
 
@@ -70,7 +70,7 @@
 
           prometheus.remote_write "mimir" {
             endpoint {
-              url = "https://spechtlabs-mimir.k8s.specht-labs.de/api/v1/push"
+              url = "http://spechtlabs-mimir.k8s.specht-labs.de/api/v1/push"
             }
           }
 
@@ -100,6 +100,6 @@
 
           otelcol.exporter.otlphttp "tempo" {
             client {
-              endpoint = "https://spechtlabs-tempo.k8s.specht-labs.de/otlp"
+              endpoint = "http://spechtlabs-tempo.k8s.specht-labs.de"
             }
           }

--- a/playbooks/monitoring-jitsi.yml
+++ b/playbooks/monitoring-jitsi.yml
@@ -3,7 +3,7 @@
   gather_facts: true
   become: true
   collections:
-    - grafana.grafana:5.7.0
+    - grafana.grafana:6.1.0
   roles:
     - role: geerlingguy.node_exporter
     - role: grafana.grafana.alloy
@@ -12,15 +12,13 @@
           - "systemd-journal"
           - "adm"
           - "sudo"
-        alloy_systemd_override:
-          alloy_systemd_override: |
-            [Service]
-            User=root
+        alloy_systemd_override: |
+          [Service]
+          User=root
         alloy_config: |
           loki.write "grafana_loki" {
             endpoint {
-              url       = "https://loki-gateway.sphinx-map.ts.net/loki/api/v1/push"
-              tenant_id = "cedi-dev"
+              url = "https://spechtlabs-loki.k8s.specht-labs.de/loki/api/v1/push"
             }
 
             external_labels = {
@@ -76,10 +74,7 @@
 
           prometheus.remote_write "mimir" {
             endpoint {
-              url = "https://mimir-nginx.sphinx-map.ts.net/api/v1/push"
-              headers = {
-                "X-Scope-OrgID" = "cedi-dev",
-              }
+              url = "https://spechtlabs-mimir.k8s.specht-labs.de/api/v1/push"
             }
           }
 
@@ -107,8 +102,8 @@
             forward_to = [prometheus.remote_write.mimir.receiver]
           }
 
-          otelcol.exporter.otlp "tempo" {
+          otelcol.exporter.otlphttp "tempo" {
             client {
-              endpoint = "tempo-distributor.sphinx-map.ts.net/otlp-http"
+              endpoint = "https://spechtlabs-tempo.k8s.specht-labs.de/otlp"
             }
           }

--- a/playbooks/monitoring-jitsi.yml
+++ b/playbooks/monitoring-jitsi.yml
@@ -18,7 +18,7 @@
         alloy_config: |
           loki.write "grafana_loki" {
             endpoint {
-              url = "https://spechtlabs-loki.k8s.specht-labs.de/loki/api/v1/push"
+              url = "http://spechtlabs-loki.k8s.specht-labs.de/loki/api/v1/push"
             }
 
             external_labels = {
@@ -74,7 +74,7 @@
 
           prometheus.remote_write "mimir" {
             endpoint {
-              url = "https://spechtlabs-mimir.k8s.specht-labs.de/api/v1/push"
+              url = "http://spechtlabs-mimir.k8s.specht-labs.de/api/v1/push"
             }
           }
 
@@ -104,6 +104,6 @@
 
           otelcol.exporter.otlphttp "tempo" {
             client {
-              endpoint = "https://spechtlabs-tempo.k8s.specht-labs.de/otlp"
+              endpoint = "http://spechtlabs-tempo.k8s.specht-labs.de"
             }
           }

--- a/playbooks/monitoring.yml
+++ b/playbooks/monitoring.yml
@@ -3,7 +3,7 @@
   gather_facts: true
   become: true
   collections:
-    - grafana.grafana:5.7.0
+    - grafana.grafana:6.1.0
   roles:
     - role: geerlingguy.node_exporter
     - role: grafana.grafana.alloy
@@ -20,8 +20,7 @@
         alloy_config: |
           loki.write "grafana_loki" {
             endpoint {
-              url       = "https://loki-gateway.sphinx-map.ts.net/loki/api/v1/push"
-              tenant_id = "homelab"
+              url = "https://homelab-loki.k8s.specht-labs.de/loki/api/v1/push"
             }
           }
 
@@ -69,10 +68,7 @@
 
           prometheus.remote_write "mimir" {
             endpoint {
-              url = "https://mimir-nginx.sphinx-map.ts.net/api/v1/push"
-              headers = {
-                "X-Scope-OrgID" = "homelab",
-              }
+              url = "https://homelab-mimir.k8s.specht-labs.de/api/v1/push"
             }
           }
 
@@ -182,10 +178,18 @@
             forward_to = [prometheus.remote_write.mimir.receiver]
           }
 
-          otelcol.exporter.otlp "tempo" {
+          otelcol.exporter.otlphttp "tempo" {
             client {
-              endpoint = "tempo-distributor.sphinx-map.ts.net/otlp-http"
+              endpoint = "https://homelab-tempo.k8s.specht-labs.de/otlp"
             }
+          }
+
+          otelcol.exporter.prometheus "to_mimir" {
+            forward_to = [prometheus.remote_write.mimir.receiver]
+          }
+
+          otelcol.exporter.loki "to_loki" {
+            forward_to = [loki.write.grafana_loki.receiver]
           }
 
           otelcol.receiver.otlp "default" {
@@ -196,8 +200,8 @@
               endpoint = "0.0.0.0:4318"
             }
             output {
-              metrics = [otelcol.exporter.otlp.tempo.input]
-              logs    = [otelcol.exporter.otlp.tempo.input]
-              traces  = [otelcol.exporter.otlp.tempo.input]
+              metrics = [otelcol.exporter.prometheus.to_mimir.input]
+              logs    = [otelcol.exporter.loki.to_loki.input]
+              traces  = [otelcol.exporter.otlphttp.tempo.input]
             }
           }

--- a/playbooks/monitoring.yml
+++ b/playbooks/monitoring.yml
@@ -20,7 +20,7 @@
         alloy_config: |
           loki.write "grafana_loki" {
             endpoint {
-              url = "https://homelab-loki.k8s.specht-labs.de/loki/api/v1/push"
+              url = "http://homelab-loki.k8s.specht-labs.de/loki/api/v1/push"
             }
           }
 
@@ -68,7 +68,7 @@
 
           prometheus.remote_write "mimir" {
             endpoint {
-              url = "https://homelab-mimir.k8s.specht-labs.de/api/v1/push"
+              url = "http://homelab-mimir.k8s.specht-labs.de/api/v1/push"
             }
           }
 
@@ -180,7 +180,7 @@
 
           otelcol.exporter.otlphttp "tempo" {
             client {
-              endpoint = "https://homelab-tempo.k8s.specht-labs.de/otlp"
+              endpoint = "http://homelab-tempo.k8s.specht-labs.de"
             }
           }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Ansible controller-side Python dependencies.
+# Install via `mise run deps` (uses uv into the ansible-core venv).
+# netaddr is required by ansible.utils.ipaddr, used by the grafana.grafana.alloy
+# role preflight to validate the alloy server.http.listen-addr.
+netaddr==1.3.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,6 +2,7 @@
 collections:
   - name: community.general
   - name: ansible.posix
+  - name: ansible.utils
   - name: grafana.grafana
     version: "6.1.0"
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,6 +3,7 @@ collections:
   - name: community.general
   - name: ansible.posix
   - name: grafana.grafana
+    version: "6.1.0"
 
 roles:
   - name: geerlingguy.node_exporter


### PR DESCRIPTION
## Goal

Move the Grafana Alloy fleet (nuc, hole, jitsi) off the old `*.sphinx-map.ts.net` tailscale-serve endpoints and onto the new envoy tailnet Gateway endpoints, upgrade the `grafana.grafana` collection to 6.1.0, and fix an OTLP routing bug that was silently dropping every OTLP-ingested metric and log on nuc.

## Rationale

The new endpoints inject the multi-tenant `X-Scope-OrgID` header server-side (per-hostname HTTPRoutes), so clients no longer need to set tenant headers. nuc maps to the `homelab-*` endpoints; hole and jitsi (formerly the `cedi-dev` tenant) map to `spechtlabs-*`.

The endpoints are served over plain HTTP on the gateway's `:80` listener (Tailscale/WireGuard already encrypts transport); the `:443` listener is TLS passthrough for TLSRoutes only. So the URLs use `http://`, not `https://`. This was discovered during deploy: `https://` reset at the TLS handshake because no cert is served for these hostnames. Tempo's OTLP/HTTP receiver (`tempo-distributor:4318`) serves `/v1/traces`, so the exporter endpoint is the bare host and Alloy appends the path.

Separately, nuc's `otelcol.receiver.otlp` was forwarding metrics, logs, and traces all into the single Tempo exporter. The live journal showed a continuous stream of connection-refused / queue-full / dropping-data errors against the dead old Tempo. The fix routes each signal to its correct backend:

```alloy
otelcol.exporter.prometheus "to_mimir" { forward_to = [prometheus.remote_write.mimir.receiver] }
otelcol.exporter.loki       "to_loki"  { forward_to = [loki.write.grafana_loki.receiver] }

otelcol.receiver.otlp "default" {
  output {
    metrics = [otelcol.exporter.prometheus.to_mimir.input]
    logs    = [otelcol.exporter.loki.to_loki.input]
    traces  = [otelcol.exporter.otlphttp.tempo.input]
  }
}
```

## Changes

All three playbooks: bump the inline collection pin to 6.1.0, point Loki/Mimir/Tempo at the new `http://` endpoints, drop `tenant_id` and `X-Scope-OrgID` (server injects them), and switch Tempo to `otelcol.exporter.otlphttp`. hole and jitsi also get the `alloy_systemd_override` un-nested so the `User=root` override actually applies.

The 6.1.0 alloy role preflight validates the listen-addr with `ansible.utils.ipaddr`, which needs the `ansible.utils` collection plus the `netaddr` Python lib on the controller. Added `ansible.utils` to `requirements.yml`, a pinned `requirements.txt` for `netaddr`, and a `mise run deps` task that installs both (netaddr via uv into the ansible-core venv).

Design and plan docs are under `docs/superpowers/`.

## Notes

Applied and verified live on nuc: Alloy upgraded v1.8.1 to v1.17.0, and Alloy's internal counters confirm delivery (mimir `samples_failed_total=0`, loki `dropped_*=0`, tempo `sent_spans_total` climbing). hole and jitsi are committed but not yet applied (remote hosts); apply with `mise exec -- ansible-playbook -i inventory/homelab.yaml playbooks/monitoring-hole.yml` (and the jitsi equivalent) when reachable.